### PR TITLE
handle cases there is no simbad or ned type provided

### DIFF
--- a/adsdata/file_defs.py
+++ b/adsdata/file_defs.py
@@ -10,7 +10,7 @@ data_files['author'] = {'path': 'links/facet_authors/all.links', 'default_value'
 data_files['citation'] = {'path': 'links/citation/all.links', 'default_value': [], 'multiline': True}
 data_files['download'] = {'path': 'links/reads/downloads.links', 'default_value': []}
 data_files['grants'] = {'path': 'links/grants/all.links', 'default_value': [], 'string_to_number': False, 'multiline': True}
-data_files['ned_objects'] = {'path': 'links/ned/ned_objects.tab', 'default_value': [], 'string_to_number': False, 'multiline': True, 'tabs_to_spaces': True}
+data_files['ned_objects'] = {'path': 'links/ned/ned_objects.tab', 'default_value': [], 'string_to_number': False, 'multiline': True, 'tab_separated_pair': True}
 data_files['nonarticle'] = {'path': 'links/nonarticle/all.links', 'default_value': False, 'multiline': True}
 data_files['ocrabstract'] = {'path': 'links/ocr/all.links', 'default_value': False,
                              'extra_values': {'property': ['OCRABSTRACT']}}
@@ -25,7 +25,7 @@ data_files['reference'] = {'path': 'links/reference/all.links', 'default_value':
 data_files['relevance'] = {'path': 'links/relevance/docmetrics.tab', 'default_value': {},
                            'subparts': ['boost', 'citation_count', 'read_count', 'norm_cites']}
 data_files['simbad_objects'] = {'path': 'links/simbad/simbad_objects.tab', 'default_value': [],
-                                'string_to_number': False, 'multiline': True, 'tabs_to_spaces': True}
+                                'string_to_number': False, 'multiline': True, 'tab_separated_pair': True}
 
 data_files['pub_html'] = {'path': 'links/electr/all.links', 'default_value': {},
                           'extra_values': {'link_type': 'ESOURCE', 'link_sub_type': 'PUB_HTML'},

--- a/adsdata/reader.py
+++ b/adsdata/reader.py
@@ -130,7 +130,7 @@ class NonbibFileReader(object):
             if 'extra_values' in self.file_info and value != self.file_info['default_value']:
                 d.update(self.file_info['extra_values'])
             return {self.filetype: d}
-        elif (len(value) > 0 and '\t' in value[0] and not self.file_info.get('tabs_to_spaces', False)):
+        elif (len(value) > 0 and '\t' in value[0] and not self.file_info.get('tab_separated_pair', False)):
             # tab separator in string means we need to convert elements to array
             z = []
             for r in value:
@@ -163,11 +163,15 @@ class NonbibFileReader(object):
                         v = parts[i].strip()
                         x[k].append(v)
             return_value = x
-        elif (self.file_info.get('tabs_to_spaces', False)):
-            # files like simbad_objects have tabs that we simply convert to spaces
+        elif (self.file_info.get('tab_separated_pair', False)):
+            # files like simbad_objects, ned_objects have tabs separating an id and 0 or more types
             x = []
             for a in value:
-                x.append(a.replace('\t', ' '))
+                t = a.replace('\t', ' ')
+                if ' ' not in t:
+                    # when no type is present we need a trailing space
+                    t += ' '
+                x.append(t)
             return_value = x
         elif (len(value) > 1):
             x = []

--- a/adsdata/tests/test_reader.py
+++ b/adsdata/tests/test_reader.py
@@ -227,6 +227,10 @@ EEEEEEEEEEEEEEEEEEE\tE""")):
             f = reader.NonbibFileReader('simbad_objects', data_files['simbad_objects'])
             v = f.read_value_for('2010A&A...521A..55C')
             self.assertEqual({'simbad_objects': ['2419335 reg', '3754378 GrG']}, v)
+        with patch('builtins.open', return_value=StringIO('1991PASP..103..494P\t947046\t')):
+            f = reader.NonbibFileReader('simbad_objects', data_files['simbad_objects'])
+            v = f.read_value_for('1991PASP..103..494P')
+            self.assertEqual({'simbad_objects': ['947046 ']}, v)
 
     def test_ned(self):
         self.maxDiff = None
@@ -234,6 +238,10 @@ EEEEEEEEEEEEEEEEEEE\tE""")):
             f = reader.NonbibFileReader('ned_objects', data_files['ned_objects'])
             v = f.read_value_for('1885AN....112..285E')
             self.assertEqual({'ned_objects': ["MESSIER_031 G", "SN_1885A SN"]}, v)
+        with patch('builtins.open', return_value=StringIO('1885AN....112..285E\tMESSIER_031\tG\n1885AN....112..285E\tSN_1885A')):
+            f = reader.NonbibFileReader('ned_objects', data_files['ned_objects'])
+            v = f.read_value_for('1885AN....112..285E')
+            self.assertEqual({'ned_objects': ["MESSIER_031 G", "SN_1885A "]}, v)
 
     def test_presentation(self):
         self.maxDiff = None


### PR DESCRIPTION
files contain id <tab> type
normal processing converts tabs to spaces
when no type is provided (which is very rare) input is converted to just id
but master wants to split on first space which separates id from types
this change provides a trailing space so the split on master works
should grants also specify tab_separated_pair