### PR TITLE
Force command line sorting to be byte-wise by setting LC_ALL=C

### DIFF
--- a/adsdata/diffs.py
+++ b/adsdata/diffs.py
@@ -1,4 +1,4 @@
-
+import os
 from subprocess import PIPE, Popen
 
 from adsdata.file_defs import data_files
@@ -6,15 +6,9 @@ from adsdata import tasks
 
 logger = tasks.app.logger
 
-    #  - _sort_input_files(root_dir='logs/input/'):
-    #  - _compute_changed_bibcodes(root_dir='logs/input/'):
-    #  - _merge_changed_bibcodes(root_dir='logs/input/'):
-    #  - _execute(command, **kwargs):
-
-
 class Diff:
     """use shell commands to generate the list of changed bibcodes
-    
+
     compares today's nonbib data to yesterday's
     list of changed bibcodes are put in a file"""
 
@@ -30,7 +24,9 @@ class Diff:
     def execute(cls, command, **kwargs):
         """execute the passed shell command"""
         logger.info('in diffs, executing shell command {}'.format(command))
-        p = Popen(command, shell=True, stdout=PIPE, stderr=PIPE, **kwargs)
+        env = os.environ.copy()
+        env["LC_ALL"] = "C" # force sorting to be byte-wise (required to be compatible with Classic generated files)
+        p = Popen(command, shell=True, stdout=PIPE, stderr=PIPE, env=env, **kwargs)
         out, err = p.communicate()
         if p.returncode != 0:
             msg = 'error executing command {}, error code = {}, out = {}, err = {}'.format(command, p.returncode, out, err)

--- a/adsdata/diffs.py
+++ b/adsdata/diffs.py
@@ -25,7 +25,7 @@ class Diff:
         """execute the passed shell command"""
         logger.info('in diffs, executing shell command {}'.format(command))
         env = os.environ.copy()
-        env["LC_ALL"] = "C" # force sorting to be byte-wise (required to be compatible with Classic generated files)
+        env["LC_ALL"] = "C" # force sorting to be byte-wise (compatible with python string comparison)
         p = Popen(command, shell=True, stdout=PIPE, stderr=PIPE, env=env, **kwargs)
         out, err = p.communicate()
         if p.returncode != 0:


### PR DESCRIPTION
The pipeline relies on command line tools such as `sort` or `comm` which change their behavior depending on the locales. The expected behavior corresponds to the one they have when the locale is set to `C` (i.e., byte-wise sorting, that's how python behaves when comparing strings) instead of other such as `en_US.UTF-8`, hence we should make sure the correct locale is set when the pipeline runs these command line tools.

```
ads@14310b8f2f74:/app (master)$ LC_ALL=en_US.UTF-8 sort <<< $'a\nb\nA\nB'
a
A
b
B
ads@14310b8f2f74:/app (master)$ LC_ALL=C sort <<< $'a\nb\nA\nB'
A
B
a
b
```

Python behaves similarly to when `LC_ALL=C` is setup, and python ignores `LC_ALL`:

```
ads@14310b8f2f74:/app (master)$ LC_ALL=en_US.UTF-8 python3 -c 'l = ["a", "b", "A", "B"]; l.sort(); print(l)'
['A', 'B', 'a', 'b']
ads@14310b8f2f74:/app (master)$ LC_ALL=C python3 -c 'l = ["a", "b", "A", "B"]; l.sort(); print(l)'
['A', 'B', 'a', 'b']
```

This behavior is also confirmed externally here: https://stackoverflow.com/a/26505745