### PR TITLE
Updates to file_defs.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ bibcodes.  To update master with the changed bibcodes from a file use the comman
 #Process only Classic Records
 python3 run.py PROCESS_FILE logs/input/current/changedBibcodes.txt
 #Process Classic and CitationCapture Records
-python3 run.py PROCESS_FILE logs/input/current/changedBibcodes.txt --include-CitationCapture logs/input/current/changedBibcodes_CC.txt
+python3 run.py PROCESS_FILE logs/input/current/changedBibcodes.txt --include-CitationCapture-file logs/input/current/changedBibcodes_CC.txt
 #Process only CitationCapture Records
 python3 run.py PROCESS_FILE logs/input/current/changedBibcodes_CC.txt --only-CitationCapture
 ```

--- a/adsdata/diffs.py
+++ b/adsdata/diffs.py
@@ -60,6 +60,12 @@ class Diff:
             c = root_dir + '/current/' + data_bib[x]['path']
             p = root_dir + '/previous/' + data_bib[x]['path']
             changed_bibs = root_dir + '/current/' + data_bib[x]['path'] + '.changedbibs'
+            
+            #if the path does not exist in previous/ (possible for CC_records) initialize an empty file.
+            if not os.path.isfile(p) and CC_records:
+                command = "touch -d {}".format(p)
+                cls.execute(command)
+
             # the process to computed changed bibcodes is:
             #          find changes  | remove comm leading tab, blank lines|get bibcode|dedup|filter out non-canonical  | current, previous, output file, today's canonical bibcodes
             command = "comm -3 {} {} | sed 's/^[ \\t]*//g' | sed '/^$/d' | cut -f 1 | uniq | comm -1 -2 - {}  > {}".format(c, p, root_dir + '/current/' + data_bib['canonical']['path'], changed_bibs)

--- a/adsdata/file_defs.py
+++ b/adsdata/file_defs.py
@@ -73,9 +73,9 @@ data_files['data_link'] = {'path': 'links/facet_datasources/datasources.links', 
 # use dict to hold each input files and their properties and idiosycrasies
 data_files_CC = OrderedDict()
 data_files_CC['canonical'] = {'path': 'bibcodes_CC.list.can', 'default_value': ''}
-data_files_CC['author'] = {'path': 'links/facet_authors/all_CC.links', 'default_value': []}
-data_files_CC['citation'] = {'path': 'links/citation/all_CC.links', 'default_value': [], 'multiline': True}
-data_files_CC['reference'] = {'path': 'links/reference/all_CC.links', 'default_value': [], 'multiline': True}
+data_files_CC['author'] = {'path': 'links/facet_authors/facet_authors_CC.list', 'default_value': []}
+data_files_CC['citation'] = {'path': 'links/citation/citations_CC.list', 'default_value': [], 'multiline': True}
+data_files_CC['reference'] = {'path': 'links/reference/references_CC.list', 'default_value': [], 'multiline': True}
 data_files_CC['download'] = {'path': 'links/reads/downloads.links', 'default_value': []}
 data_files_CC['reads'] = {'path': 'links/reads/all.links', 'default_value': []}
 


### PR DESCRIPTION
Changed CC file names to prevent interference with *.links indexing. Added check in diffs.py to create empty CC files in previous if they do not exist so DataPipeline can run on first import of CC records.